### PR TITLE
Improved usability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,9 +81,13 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv/
 
 # Spyder project settings
 .spyderproject
 
 # Rope project settings
 .ropeproject
+
+# Visual Studio Code
+.vscode/


### PR DESCRIPTION
Actual py_inspect version use fixed window size. It's not particularly user-friendly. With Qt GridLayout the user can decide by themself which window size fits the requirements (screen resolution, personal preferences, etc.). After the user closes the window, py_inspect store actual window geometry and restore it again with next application start.

Additional it would be good to extend attribute list, so I started with automation_id.